### PR TITLE
feat: teach tool to filter calls by org/method and dump to file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,11 @@ pbbinarylog  = { path = "./pbbinarylog" }
 # pull generated_types (which includes the influx rpc protobuf definitions) from the IOx repo
 # TODO: it would be nice if the storage rpc were broken down into their own crate (separate from the iox management protos)
 generated_types = { git = "https://github.com/influxdata/influxdb_iox.git", rev="85aa019f5004a0c6c536a75384d7dd2428547beb" }
-bytes = "1.0"
+bytes = { version = "1.0", features = ["serde"] }
 chrono = "0.4.19"
 prost = "0.9"
+bincode = "1.3.3"
+serde = { version = "1.0.136", features = ["derive"] }
 
 [workspace]
 members = [

--- a/src/call.rs
+++ b/src/call.rs
@@ -1,13 +1,14 @@
 use std::{collections::HashMap, fmt::Display};
 
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 
 use crate::methods::{Method, MethodType};
 
 /// Represents a logical gRPC call extracted from a chain of Entrys
 ///
 ///
-#[derive(Default, Debug, Clone)]
+#[derive(Clone, Serialize, Deserialize, Default, Debug)]
 pub struct Call {
     pub id: u64,
 

--- a/src/calls.rs
+++ b/src/calls.rs
@@ -39,34 +39,23 @@ impl Calls {
         self.calls.extend(other.calls.into_iter());
     }
 
-    // Consumes self and returns a new [`Calls`] with offset calls filtered out.
-    pub fn filter_offset_calls(self) -> Self {
-        Self {
-            calls: self
-                .calls
-                .into_iter()
-                .filter(|c| {
-                    c.method_name
-                        .as_ref()
-                        .map(|method| !method.eq("/influxdata.platform.storage.Storage/Offsets"))
-                        .unwrap_or(false)
-                })
-                .collect(),
-        }
+    // Filters calls for Offsets from the collection.
+    pub fn filter_offset_calls(&mut self) {
+        self.calls.retain(|c| {
+            c.method_name
+                .as_ref()
+                .map(|method| !method.eq("/influxdata.platform.storage.Storage/Offsets"))
+                .unwrap_or(false)
+        })
     }
 
-    // Consumes self and returns a new [`Calls`] with calls not belonging to the provided org_id filtered out.
-    pub fn filter_by_org_id(self, org_id: &str) -> Self {
-        Self {
-            calls: self
-                .calls
-                .into_iter()
-                .filter(|c| match c.client_headers.get(INFLUX_ORG_ID_HEADER_NAME) {
-                    Some(id) => id.as_str() == org_id,
-                    None => false,
-                })
-                .collect(),
-        }
+    // Filters calls not belonging to the provided org_id from the collection.
+    pub fn filter_by_org_id(&mut self, org_id: &str) {
+        self.calls
+            .retain(|c| match c.client_headers.get(INFLUX_ORG_ID_HEADER_NAME) {
+                Some(id) => id.as_str() == org_id,
+                None => false,
+            });
     }
 }
 

--- a/src/calls.rs
+++ b/src/calls.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeMap;
 
+use serde::{Deserialize, Serialize};
+
 use crate::{
     call::Call,
     entry::{ClientHeader, Entry, EventType, Logger, Message, Payload, ServerHeader, Trailer},
@@ -14,7 +16,7 @@ use crate::{
 ///   // do awesome stuff
 /// }
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Calls {
     /// Calls that are build from the overall records
     calls: Vec<Call>,

--- a/src/calls.rs
+++ b/src/calls.rs
@@ -35,6 +35,22 @@ impl Calls {
     pub fn extend_from_other(&mut self, other: Self) {
         self.calls.extend(other.calls.into_iter());
     }
+
+    // consumes self and returns a new `Calls` with offset calls filtered out.
+    pub fn filter_offset_calls(self) -> Self {
+        Self {
+            calls: self
+                .calls
+                .into_iter()
+                .filter(|c| {
+                    c.method_name
+                        .as_ref()
+                        .map(|method| !method.eq("/influxdata.platform.storage.Storage/Offsets"))
+                        .unwrap_or(false)
+                })
+                .collect(),
+        }
+    }
 }
 
 impl<A: Into<Entry>> FromIterator<A> for Calls {

--- a/src/calls.rs
+++ b/src/calls.rs
@@ -16,7 +16,7 @@ use crate::{
 ///   // do awesome stuff
 /// }
 /// ```
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Default, Clone, Serialize, Deserialize, Debug)]
 pub struct Calls {
     /// Calls that are build from the overall records
     calls: Vec<Call>,
@@ -29,6 +29,11 @@ impl Calls {
 
     pub fn iter(&self) -> impl Iterator<Item = &Call> {
         self.calls.iter()
+    }
+
+    // appends `other` into a new [`Calls`].
+    pub fn extend_from_other(&mut self, other: Self) {
+        self.calls.extend(other.calls.into_iter());
     }
 }
 

--- a/src/dump_calls.rs
+++ b/src/dump_calls.rs
@@ -70,12 +70,8 @@ impl DumpCalls {
 
         // collect into calls
         let calls: Calls = ok_entries.into_iter().collect();
-        let call_len = calls.len();
         println!("Found {} calls", calls.len());
 
-        // Filter the "Offsets" calls out
-        let calls = calls.filter_offset_calls();
-        println!("Filtered {} offset calls", call_len - calls.len());
         Ok(calls)
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,3 +26,11 @@ impl From<String> for Error {
         Self { msg }
     }
 }
+
+impl From<&'static str> for Error {
+    fn from(msg: &'static str) -> Self {
+        Self {
+            msg: msg.to_string(),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,7 @@ fn main() {
             }
 
             let mut dc = dump_calls::DumpCalls::new(dump.input_path);
-            let calls = match dc.process() {
+            let mut calls = match dc.process() {
                 Ok(calls) => calls,
                 Err(e) => {
                     eprintln!("{}", e);
@@ -104,22 +104,19 @@ fn main() {
             };
 
             // Filter offset calls out
-            let calls = calls.filter_offset_calls();
+            calls.filter_offset_calls();
             println!("Filtered offset calls. {:?} calls remaining", calls.len());
 
             // Filter by org_id
-            let calls = if dump.org_filter.is_empty() {
-                calls
-            } else {
+            if !dump.org_filter.is_empty() {
                 let org_filter = dump.org_filter.as_str();
-                let calls = calls.filter_by_org_id(org_filter);
+                calls.filter_by_org_id(org_filter);
                 println!(
                     "Filtered calls not for org id {}. {:?} calls remaining",
                     org_filter,
                     calls.len()
                 );
-                calls
-            };
+            }
 
             let res = match dump.format {
                 CallFormat::Pretty => dc.write_calls_pretty(calls, &mut stdout()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,10 @@ struct DumpCalls {
     #[clap(long)]
     /// Format to emit processed gRPC calls
     format: CallFormat,
+
+    #[clap(long, default_value = "")]
+    /// optional filter on org_id
+    org_filter: String,
 }
 
 #[derive(Debug)]
@@ -97,6 +101,24 @@ fn main() {
                     eprintln!("{}", e);
                     return;
                 }
+            };
+
+            // Filter offset calls out
+            let calls = calls.filter_offset_calls();
+            println!("Filtered offset calls. {:?} calls remaining", calls.len());
+
+            // Filter by org_id
+            let calls = if dump.org_filter.is_empty() {
+                calls
+            } else {
+                let org_filter = dump.org_filter.as_str();
+                let calls = calls.filter_by_org_id(org_filter);
+                println!(
+                    "Filtered calls not for org id {}. {:?} calls remaining",
+                    org_filter,
+                    calls.len()
+                );
+                calls
             };
 
             let res = match dump.format {

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,12 +86,18 @@ fn main() {
         }
         InfluxRpcCompare::DumpCalls(dump) => {
             let mut dc = dump_calls::DumpCalls::new(dump.input_path);
-            match dump.format {
-                CallFormat::Pretty => dc.dump(&mut stdout()).expect("Error dumping calls"),
-                CallFormat::Binary => todo!(),
+            let res = match dump.format {
+                CallFormat::Pretty => match dc.process() {
+                    Ok(calls) => dc.write_calls_pretty(calls, &mut stdout()),
+                    Err(e) => Err(e),
+                },
+                CallFormat::Binary => Err("unimplemented".into()),
+            };
+
+            match res {
+                Ok(_) => println!("Completed successfully"),
+                Err(e) => eprintln!("{}", e),
             }
         }
     };
-
-    println!("Done");
 }

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -3,6 +3,7 @@ use generated_types::influxdata::platform::storage::{
     CapabilitiesResponse, OffsetsResponse, ReadResponse, ReadWindowAggregateRequest,
     StringValuesResponse, TagKeysRequest, TagValuesRequest,
 };
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy)]
 pub enum MethodType {
@@ -11,7 +12,7 @@ pub enum MethodType {
 }
 
 /// All the GRPC methods this code knows how to decode to native form
-#[derive(Debug, Clone)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub enum Method {
     /// `/influxdata.platform.storage.Storage/Offsets`
     /// No special decoding (yet)


### PR DESCRIPTION
This PR teaches the tool to filter out uninteresting gRPC calls and to optionally filter on provided org ids.

The gRPC calls are then binary encoded and written to a file for a subsequent stage in the data pipeline.

```
$ influxrpc_compare dump-calls --in ~/tsm.txt --format bin --out /tmp/output.bin --org-filter some_org_id
```